### PR TITLE
Improvements for building in-tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ default:
 	mkdir -p $(DEST)
 	find $(DEST)/ -type l -exec rm {} +
 	ln -sr src/* $(DEST)/
-	$(MAKE) -C $(KDIR) M=$(abspath $(DEST))
+	$(MAKE) -C $(KDIR) M=$(abspath $(DEST)) CONFIG_HID_ITHC=m
 
 install:
-	$(MAKE) -C $(KDIR) M=$(abspath $(DEST)) modules_install
+	$(MAKE) -C $(KDIR) M=$(abspath $(DEST)) CONFIG_HID_ITHC=m modules_install
 	depmod -a
 	sync
 

--- a/src/Kbuild
+++ b/src/Kbuild
@@ -1,4 +1,4 @@
-obj-m := ithc.o
+obj-$(CONFIG_HID_ITHC) := ithc.o
 
 ithc-objs := ithc-main.o ithc-regs.o ithc-dma.o ithc-debug.o
 

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -1,0 +1,12 @@
+config HID_ITHC
+	tristate "Intel Touch Host Controller"
+	depends on PCI
+	depends on HID
+	help
+	  Say Y here if your system has a touchscreen using Intels
+	  Touch Host Controller (ITHC / IPTS) technology.
+
+	  If unsure say N.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ithc.


### PR DESCRIPTION
With this change, building ITHC in-tree will be as easy as copying the `src` folder somewhere under `drivers/` and hooking it up to the rest of the build system. It also allows to build the driver directly into vmlinux instead of unconditionally building as a module.