### PR TITLE
fix broken build starting with kernel 6.10

### DIFF
--- a/src/ithc-main.c
+++ b/src/ithc-main.c
@@ -332,7 +332,7 @@ static int ithc_start(struct pci_dev *pci)
 
 	// Initialize HID and DMA.
 	CHECK_RET(ithc_hid_init, ithc);
-	CHECK(devm_device_add_groups, &pci->dev, ithc_attribute_groups);
+	CHECK(device_add_groups, &pci->dev, ithc_attribute_groups);
 	if (ithc_use_rx0)
 		CHECK_RET(ithc_dma_rx_init, ithc, 0);
 	if (ithc_use_rx1)

--- a/src/ithc.h
+++ b/src/ithc.h
@@ -14,6 +14,7 @@
 #include <linux/module.h>
 #include <linux/pci.h>
 #include <linux/poll.h>
+#include <linux/vmalloc.h>
 
 #define DEVNAME "ithc"
 #define DEVFULLNAME "Intel Touch Host Controller"


### PR DESCRIPTION
This fixes the build for kernel 6.10. Also seems to continue building for 6.9, but didn't check any earlier versions. I also didn't find if/where deprecation of those symbols occurred.

Let me know if there is a better way to do this.