### PR TITLE
Improve error recovery, locking, and shutdown behavior

### DIFF
--- a/src/ithc-debug.c
+++ b/src/ithc-debug.c
@@ -39,17 +39,19 @@ static ssize_t ithc_debugfs_cmd_write(struct file *f, const char __user *buf, si
 
 	// Parse the list of arguments into a u32 array.
 	u32 n = 0;
-	const char *s = cmd + 1;
+	char *s = cmd + 1;
 	u32 a[32];
-	while (*s && *s != '\n') {
+	while (*s) {
 		if (n >= ARRAY_SIZE(a))
 			return -EINVAL;
 		if (*s++ != ' ')
 			return -EINVAL;
-		char *e;
-		a[n++] = simple_strtoul(s, &e, 0);
-		if (e == s)
+		char *e = strchrnul(s, ' ');
+		char c = *e;
+		*e = 0;
+		if (kstrtou32(s, 0, &a[n++]))
 			return -EINVAL;
+		*e = c;
 		s = e;
 	}
 	ithc_log_regs(ithc);
@@ -57,7 +59,7 @@ static ssize_t ithc_debugfs_cmd_write(struct file *f, const char __user *buf, si
 	// Execute the command.
 	switch (cmd[0]) {
 	case 'x': // reset
-		ithc_reset(ithc);
+		schedule_work(&ithc->reset_work);
 		break;
 	case 'w': // write register: offset mask value
 		if (n != 3 || (a[0] & 3))

--- a/src/ithc-hid.c
+++ b/src/ithc-hid.c
@@ -106,7 +106,8 @@ void ithc_hid_process_data(struct ithc *ithc, struct ithc_data *d)
 		return;
 
 	case ITHC_DATA_ERROR:
-		CHECK(ithc_reset, ithc);
+		// This is called during DMA processing, so the reset must be done asynchronously.
+		schedule_work(&ithc->reset_work);
 		return;
 
 	case ITHC_DATA_REPORT_DESCRIPTOR:
@@ -120,6 +121,8 @@ void ithc_hid_process_data(struct ithc *ithc, struct ithc_data *d)
 	{
 		// Standard HID input report.
 		int r = hid_input_report(ithc->hid.dev, HID_INPUT_REPORT, NOCONST(d->data), d->size, 1);
+		if (r == -ENODEV || r == -EBUSY)
+			return;
 		if (r < 0) {
 			pci_warn(ithc->pci, "hid_input_report failed with %i (size %u, report ID 0x%02x)\n",
 				r, d->size, d->size ? *(u8 *)d->data : 0);

--- a/src/ithc-main.c
+++ b/src/ithc-main.c
@@ -50,7 +50,7 @@ MODULE_PARM_DESC(idleltr, "Idle LTR value override (in microseconds)");
 
 static unsigned int ithc_idle_delay_ms = 1000;
 module_param_named(idledelay, ithc_idle_delay_ms, uint, 0);
-MODULE_PARM_DESC(idleltr, "Minimum idle time before applying idle LTR value (in milliseconds)");
+MODULE_PARM_DESC(idledelay, "Minimum idle time before applying idle LTR value (in milliseconds)");
 
 static bool ithc_log_regs_enabled = false;
 module_param_named(logregs, ithc_log_regs_enabled, bool, 0);
@@ -213,7 +213,7 @@ static int ithc_init_device(struct ithc *ithc)
 	return 0;
 }
 
-int ithc_reset(struct ithc *ithc)
+static int ithc_reset(struct ithc *ithc)
 {
 	// FIXME This should probably do devres_release_group()+ithc_start().
 	// But because this is called during DMA processing, that would have to be done
@@ -229,6 +229,12 @@ int ithc_reset(struct ithc *ithc)
 	return 0;
 }
 
+static void ithc_reset_work_func(struct work_struct *work)
+{
+	struct ithc *ithc = container_of(work, struct ithc, reset_work);
+	CHECK(ithc_reset, ithc);
+}
+
 static void ithc_stop(void *res)
 {
 	struct ithc *ithc = res;
@@ -239,6 +245,8 @@ static void ithc_stop(void *res)
 		CHECK(kthread_stop, ithc->poll_thread);
 	if (ithc->irq >= 0)
 		disable_irq(ithc->irq);
+	// Poll/irq processing is stopped, so no new resets can be scheduled beyond this point.
+	cancel_work_sync(&ithc->reset_work);
 	if (ithc->use_quickspi)
 		ithc_quickspi_exit(ithc);
 	else
@@ -282,6 +290,7 @@ static int ithc_start(struct pci_dev *pci)
 		return -ENOMEM;
 	ithc->irq = -1;
 	ithc->pci = pci;
+	spin_lock_init(&ithc->ltr_lock);
 	snprintf(ithc->phys, sizeof(ithc->phys), "pci-%s/" DEVNAME, pci_name(pci));
 	pci_set_drvdata(pci, ithc);
 	CHECK_RET(devm_add_action_or_reset, &pci->dev, ithc_clear_drvdata, pci);
@@ -316,6 +325,7 @@ static int ithc_start(struct pci_dev *pci)
 	CHECK_RET(ithc_dma_tx_init, ithc);
 
 	timer_setup(&ithc->idle_timer, ithc_idle_timer_callback, 0);
+	INIT_WORK(&ithc->reset_work, ithc_reset_work_func);
 
 	// Add ithc_stop() callback AFTER setting up DMA buffers, so that polling/irqs/DMA are
 	// disabled BEFORE the buffers are freed.

--- a/src/ithc-quickspi.c
+++ b/src/ithc-quickspi.c
@@ -507,10 +507,10 @@ int ithc_quickspi_init(struct ithc *ithc, const struct ithc_acpi_config *cfg)
 
 void ithc_quickspi_exit(struct ithc *ithc)
 {
-	// TODO Should we send HIDSPI 'power off' command?
-	//struct hidspi_header h = { .type = HIDSPI_OUTPUT_TYPE_COMMAND, .id = 3, };
-	//struct ithc_data d = { .type = ITHC_DATA_RAW, .data = &h, .size = sizeof(h) };
-	//CHECK(ithc_dma_tx, ithc, &d); // or ithc_spi_command()
+	// Send the HIDSPI 'power off' command (before ithc_stop() disables DMA/NRESET).
+	struct hidspi_header h = { .type = HIDSPI_OUTPUT_TYPE_COMMAND, .id = 3, };
+	struct ithc_data d = { .type = ITHC_DATA_RAW, .data = &h, .size = sizeof(h) };
+	CHECK(ithc_dma_tx, ithc, &d);
 }
 
 int ithc_quickspi_decode_rx(struct ithc *ithc, const void *src, size_t len, struct ithc_data *dest)

--- a/src/ithc-regs.c
+++ b/src/ithc-regs.c
@@ -78,14 +78,21 @@ void ithc_set_ltr_config(struct ithc *ithc, u64 active_ltr_ns, u64 idle_ltr_ns)
 	calc_ltr(&idle_ltr_ns, &idle_val, &idle_scale);
 	pci_dbg(ithc->pci, "setting active LTR value to %llu ns, idle LTR value to %llu ns\n",
 		active_ltr_ns, idle_ltr_ns);
+	unsigned long flags;
+	spin_lock_irqsave(&ithc->ltr_lock, flags);
 	writel(LTR_CONFIG_ENABLE_ACTIVE | LTR_CONFIG_ENABLE_IDLE | LTR_CONFIG_APPLY |
 		LTR_CONFIG_ACTIVE_LTR_SCALE(active_scale) | LTR_CONFIG_ACTIVE_LTR_VALUE(active_val) |
 		LTR_CONFIG_IDLE_LTR_SCALE(idle_scale) | LTR_CONFIG_IDLE_LTR_VALUE(idle_val),
 		&ithc->regs->ltr_config);
+	spin_unlock_irqrestore(&ithc->ltr_lock, flags);
 }
 
 void ithc_set_ltr_idle(struct ithc *ithc)
 {
+	// The idle timer can fire while the LTR config is being rewritten (e.g. by the reset
+	// work), so the read-modify-write must be protected by ltr_lock.
+	unsigned long flags;
+	spin_lock_irqsave(&ithc->ltr_lock, flags);
 	u32 ltr = readl(&ithc->regs->ltr_config);
 	switch (ltr & (LTR_CONFIG_STATUS_ACTIVE | LTR_CONFIG_STATUS_IDLE)) {
 	case LTR_CONFIG_STATUS_IDLE:
@@ -97,6 +104,7 @@ void ithc_set_ltr_idle(struct ithc *ithc)
 		pci_err(ithc->pci, "invalid LTR state 0x%08x\n", ltr);
 		break;
 	}
+	spin_unlock_irqrestore(&ithc->ltr_lock, flags);
 }
 
 int ithc_set_spi_config(struct ithc *ithc, u8 clkdiv, bool clkdiv8, u8 read_mode, u8 write_mode)

--- a/src/ithc.h
+++ b/src/ithc.h
@@ -16,6 +16,7 @@
 #include <linux/poll.h>
 #include <linux/timer.h>
 #include <linux/vmalloc.h>
+#include <linux/workqueue.h>
 
 #define DEVNAME "ithc"
 #define DEVFULLNAME "Intel Touch Host Controller"
@@ -68,6 +69,8 @@ struct ithc {
 	int irq;
 	struct task_struct *poll_thread;
 	struct timer_list idle_timer;
+	struct work_struct reset_work;
+	spinlock_t ltr_lock;
 
 	struct ithc_registers __iomem *regs;
 	struct ithc_registers *prev_regs; // for debugging
@@ -84,6 +87,4 @@ struct ithc {
 	u32 max_tx_size;
 	u32 legacy_touch_cfg;
 };
-
-int ithc_reset(struct ithc *ithc);
 


### PR DESCRIPTION
 A few fixes that came out of chasing log spam and reset behavior on my Surface Laptop Studio 2 (both the touchscreen and the haptic touchpad sit behind the THC on this machine, both in quickspi mode).

The main one: resets triggered by ITHC_DATA_ERROR were running synchronously inside the DMA RX processing path, which the FIXME in ithc_reset() already warns about. I moved the reset onto a work item like the comment suggests. The debugfs x command goes through the same work item now, which also let ithc_reset() become static.

While in there I noticed the idle timer callback does a read-modify-write of ltr_config with nothing preventing a concurrent write from the init path, so LTR register access is under a small spinlock now.

I also took a shot at the TODO in ithc_quickspi_exit() and enabled the commented-out power off command. Module reloads and suspend/resume cycles all work fine with it on my machine, but I only have the one device, so if you'd rather see it tested on other devices first I can split it out of this PR.

Some other smaller stuff:
1. stopped logging hid_input_report() failures for -ENODEV/-EBUSY. These fire for every report that arrives between DMA enable and hid_add_device() completing, which was about 90 lines of dmesg per probe/resume here
2. fixed the MODULE_PARM_DESC for idledelay (it was attached to idleltr)
3. replaced simple_strtoul with kstrtou32 in the debugfs parser, checkpatch complains about the former

Tested on the SLS2 (Arch, linux-surface 6.19.8): many module reloads, several suspend/resume cycles, touch and pen and touchpad all working, nothing unexpected in dmesg.